### PR TITLE
Bug fix for xml field being empty

### DIFF
--- a/src/Rainbow.Storage.Sc/Deserialization/DefaultDeserializer.cs
+++ b/src/Rainbow.Storage.Sc/Deserialization/DefaultDeserializer.cs
@@ -504,7 +504,7 @@ namespace Rainbow.Storage.Sc.Deserialization
 				return true;
 			}
 
-			if (!field.Value.Equals(itemField.Value))
+			if (field.Value != null && !field.Value.Equals(itemField.Value))
 			{
 				var oldValue = itemField.Value;
 				itemField.SetValue(field.Value, true);

--- a/src/Rainbow/Formatting/FieldFormatters/XmlFieldFormatter.cs
+++ b/src/Rainbow/Formatting/FieldFormatters/XmlFieldFormatter.cs
@@ -28,7 +28,7 @@ namespace Rainbow.Formatting.FieldFormatters
 
 		public override string Unformat(string value)
 		{
-			if (value == null) return null;
+			if (string.IsNullOrWhiteSpace(value)) return null;
 
 			var stringBuilder = new StringBuilder();
 


### PR DESCRIPTION
Fixes an issue where an xml field (in this case a Rules field) has a value set in the standard values of a template, and a content item that still references the standard values.

The __Standard Values.yml contains:

```
SharedFields:
- ID: 12112d15-a3de-4b42-a700-de1b9666391b
  # PlaybackEventsRules
  Type: Rules
  Value: |
    <ruleset>
      <rule uid="{5A63287F-B1A0-4AB7-AA35-8022F06E14E3}">
        <conditions>
          <condition id="{4888ABBB-F17D-4485-B14B-842413F88732}" uid="6976A1A900404E5DBDD78A0DD40FB88D" />
        </conditions>
        <actions>
          <action id="{9850DB80-D70F-410B-9A5C-E825B4DE8F94}" uid="FB76160596E94C94B72C2DB67FC2F433" />
          <action id="{209A6D7F-D645-4606-8B63-678149DCDB5F}" uid="3E470589BCD741F3B408B6176E35E1FD" />
          <action id="{0FD811D2-CEC2-4121-A78C-936E579E2377}" uid="FFD920CD8FC5458889EADD5D228D2BA3" />
        </actions>
      </rule>
    </ruleset>
```

but the content item yml file has this:
```
SharedFields:
- ID: 12112d15-a3de-4b42-a700-de1b9666391b
  # PlaybackEventsRules
  Type: Rules
  Value: 
```

When the XmlFieldFormatter reads the value in, its empty instead of null and errors trying to parse the empty string as an XmlElement.

The fix checks for that and also contains an update to the `DefaultDeserializer` to cope with a null value in the field.Value property.
