### PR TITLE
#98 - The ProxyItem constructor needed to initialise the UnversionedF…

### DIFF
--- a/src/Rainbow/Model/ProxyItem.cs
+++ b/src/Rainbow/Model/ProxyItem.cs
@@ -49,6 +49,7 @@ namespace Rainbow.Model
 			DatabaseName = databaseName;
 			SharedFields = Enumerable.Empty<IItemFieldValue>();
 			Versions = Enumerable.Empty<IItemVersion>();
+			UnversionedFields = Enumerable.Empty<IItemLanguage>();
 		}
 
 		public virtual Guid Id { get; set; }


### PR DESCRIPTION
The ProxyItem constructor needed to initialise the UnversionedFields property when creating the item.

I haven't created a separate test for this because I think the `FakeItem.cs` class is masking the error, I wanted to confirm this with @kamsar before going further on that.