### PR TITLE
support relative path in SerializationFileSystemDataStore.physicalRootPath

### DIFF
--- a/src/Rainbow.Tests/Storage/SfsDataStoreTests.cs
+++ b/src/Rainbow.Tests/Storage/SfsDataStoreTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
 using FluentAssertions;
 using Xunit;
@@ -18,7 +19,16 @@ namespace Rainbow.Tests.Storage
 			}
 		}
 
-		[Fact]
+        [Fact]
+        public void InitializeRootPath_RemovesDots()
+        {
+            using (var dataStore = new TestSfsDataStore("/sitecore", Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "..\\Items")))
+            {
+                Assert.False(dataStore.PhysicalRootPathAccessor.Contains(".."));
+            }
+        }
+
+        [Fact]
 		public void Save_ErrorWhenItemNotInTree()
 		{
 			using (var dataStore = new TestSfsDataStore("/sitecore"))
@@ -340,7 +350,7 @@ namespace Rainbow.Tests.Storage
 		{
 			Assert.Throws<InvalidOperationException>(() =>
 			{
-				using (var dataStore = new TestSfsDataStore("/sitecore", "/sitecore/content"))
+				using (var dataStore = new TestSfsDataStore(new []{ "/sitecore", "/sitecore/content" }))
 				{
 					dataStore.GetByPath("/sitecore/content/home", "master");
 				}
@@ -350,7 +360,7 @@ namespace Rainbow.Tests.Storage
 		[Fact]
 		public void GetItem_DoesNotThrowError_WhenSimilarNonOverlappingPaths()
 		{
-			using (var dataStore = new TestSfsDataStore("/sitecore/content", "/sitecore/content cemetary"))
+			using (var dataStore = new TestSfsDataStore(new[] { "/sitecore/content", "/sitecore/content cemetary" }))
 			{
 				dataStore.GetByPath("/sitecore/content cemetary/foo", "master");
 			}

--- a/src/Rainbow.Tests/Storage/SfsTreeTests.Save.cs
+++ b/src/Rainbow.Tests/Storage/SfsTreeTests.Save.cs
@@ -170,7 +170,24 @@ namespace Rainbow.Tests.Storage
 			}
 		}
 
-		[Fact]
+        [Fact]
+        public void Save_WritesItem_WhenRootPathIsRelative()
+        {
+            using (var testTree = new TestSfsTree("/../../Items", "/sitecore"))
+            { 
+                testTree.CreateTestTree("/sitecore/hello");
+
+                var rootItem = testTree.GetRootItem();
+
+                var overlengthItem = testTree.GetChildren(rootItem).First();
+
+                Assert.Equal("/sitecore/hello", overlengthItem.Path);
+                Assert.EndsWith("\\Items\\sitecore\\hello.yml", overlengthItem.SerializedItemId);
+                Assert.False(overlengthItem.SerializedItemId.Contains(".."));
+            }
+        }
+
+        [Fact]
 		public void Save_WritesExpectedItems_WhenItemNameIsTooLong_AndItemsWithSameShortenedNameExist()
 		{
 			using (var testTree = new TestSfsTree())

--- a/src/Rainbow.Tests/Storage/TestSfsDataStore.cs
+++ b/src/Rainbow.Tests/Storage/TestSfsDataStore.cs
@@ -9,12 +9,24 @@ namespace Rainbow.Tests.Storage
 {
 	internal class TestSfsDataStore : SerializationFileSystemDataStore
 	{
-		public TestSfsDataStore(params string[] rootPaths) : 
+        public TestSfsDataStore(string rootPath) :
+            base(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()), false, new FakeRootFactory(new [] { rootPath }), new YamlSerializationFormatter(null, null))
+        {
+        }
+
+        public TestSfsDataStore(string[] rootPaths) : 
 			base(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()), false, new FakeRootFactory(rootPaths), new YamlSerializationFormatter(null, null))
 		{
 		}
 
-		public void CreateTestItemTree(string path, string database = "master")
+        public TestSfsDataStore(string rootPath, string physicalRootPath) :
+            base(physicalRootPath, false, new FakeRootFactory(new [] { rootPath }), new YamlSerializationFormatter(null, null))
+        {
+        }
+
+	    public string PhysicalRootPathAccessor => PhysicalRootPath;
+
+	    public void CreateTestItemTree(string path, string database = "master")
 		{
 			var tree = GetTreeForPath(path, database);
 

--- a/src/Rainbow.Tests/Storage/TestSfsTree.cs
+++ b/src/Rainbow.Tests/Storage/TestSfsTree.cs
@@ -15,7 +15,14 @@ namespace Rainbow.Tests.Storage
 			MaxFileNameLengthForTests = base.MaxItemNameLengthBeforeTruncation;
 		}
 
-		public string PrepareItemNameForFileSystemTest(string name)
+        public TestSfsTree(string physicalRootPath,  string globalRootItemPath, bool useDataCache = false)
+            : base("Unit Testing", globalRootItemPath, "UnitTesting", physicalRootPath, new YamlSerializationFormatter(null, null), useDataCache)
+        {
+            MaxPathLengthForTests = base.MaxRelativePathLength;
+            MaxFileNameLengthForTests = base.MaxItemNameLengthBeforeTruncation;
+        }
+
+        public string PrepareItemNameForFileSystemTest(string name)
 		{
 			return PrepareItemNameForFileSystem(name);
 		}

--- a/src/Rainbow/Storage/SerializationFileSystemDataStore.cs
+++ b/src/Rainbow/Storage/SerializationFileSystemDataStore.cs
@@ -25,7 +25,7 @@ namespace Rainbow.Storage
 
 		public SerializationFileSystemDataStore(string physicalRootPath, bool useDataCache, ITreeRootFactory rootFactory, ISerializationFormatter formatter)
 		{
-			Assert.ArgumentNotNullOrEmpty(physicalRootPath, "rootPath");
+			Assert.ArgumentNotNullOrEmpty(physicalRootPath, "physicalRootPath");
 			Assert.ArgumentNotNull(formatter, "formatter");
 			Assert.ArgumentNotNull(rootFactory, "rootFactory");
 
@@ -246,7 +246,12 @@ namespace Rainbow.Storage
 				rootPath = Path.Combine(HostingEnvironment.MapPath("~/"), cleanRootPath);
 			}
 
-			if (!Directory.Exists(rootPath)) Directory.CreateDirectory(rootPath);
+            //convert root path to canonical form, so subsequent transformations can do string comparison
+            //http://stackoverflow.com/questions/970911/net-remove-dots-from-the-path
+            if (rootPath.Contains(".."))
+                rootPath = Path.GetFullPath(rootPath);
+
+            if (!Directory.Exists(rootPath)) Directory.CreateDirectory(rootPath);
 
 			return rootPath;
 		}

--- a/src/Rainbow/Storage/SerializationFileSystemTree.cs
+++ b/src/Rainbow/Storage/SerializationFileSystemTree.cs
@@ -471,8 +471,11 @@ namespace Rainbow.Storage
 			if (basePath == null)
 				basePath = string.Concat(Path.ChangeExtension(parentItem.SerializedItemId, null), Path.DirectorySeparatorChar, strippedItemName, _formatter.FileExtension);
 
-			// Determine if the relative base-string is over - length(which would be 240 - $(Serialization.SerializationFolderPathMaxLength))
-			string relativeBasePath = basePath.Substring(_physicalRootPath.Length);
+            // Determine if the relative base-string is over - length(which would be 240 - $(Serialization.SerializationFolderPathMaxLength))
+            if (_physicalRootPath.Length > basePath.Length)
+                throw new Exception($"_physicalRootPath '{_physicalRootPath}' cannot be larger than '{basePath}'");
+
+            string relativeBasePath = basePath.Substring(_physicalRootPath.Length);
 			int maxPathLength = MaxRelativePathLength;
 
 			// path not over length = return it and we're done here


### PR DESCRIPTION
Relative path like below throws an Exception on Item serialization 

` <targetDataStore type="Rainbow.Storage.SerializationFileSystemDataStore, Rainbow">
          <!--<patch:attribute name="physicalRootPath">C:\prog\gitHub\alogolia-simpleui\Items</patch:attribute>-->
          <patch:attribute name="physicalRootPath">\..\..\Items</patch:attribute>
        </targetDataStore>
      </defaults>`

The same happening with web root path:

`<patch:attribute name="physicalRootPath">~/../../Items</patch:attribute>`

Call stack:

`[ArgumentOutOfRangeException: startIndex cannot be larger than length of string.
Parameter name: startIndex]
   System.String.Substring(Int32 startIndex, Int32 length) +14415512
   Rainbow.Storage.SerializationFileSystemTree.GetTargetPhysicalPath(IItemData item) +1503
   Rainbow.Storage.SerializationFileSystemTree.Save(IItemData item) +50
   Unicorn.Data.DataProvider.UnicornDataProvider.SaveItem(ItemDefinition itemDefinition, ItemChanges changes, CallContext context) +857
   Unicorn.Data.DataProvider.UnicornSqlServerDataProvider.SaveItem(ItemDefinition itemDefinition, ItemChanges changes, CallContext context) +166
   Sitecore.Data.DataProviders.DataProvider.SaveItem(ItemDefinition item, ItemChanges changes, CallContext context, DataProviderCollection providers) +124
   Sitecore.Data.DataSource.SaveItem(ID itemID, ItemChanges changes) +76
   Sitecore.Data.Engines.EngineCommand`2.Execute() +98
   Sitecore.Data.Engines.DataEngine.SaveItem(Item item) +146
   Sitecore.Data.Managers.ItemProvider.SaveItem(Item item) +322
   Sitecore.Data.Managers.PipelineBasedItemProvider.ExecuteAndReturnResult(String pipelineName, String pipelineDomain, Func`1 pipelineArgsCreator, Func`1 fallbackResult) +96
   Sitecore.Data.Managers.PipelineBasedItemProvider.SaveItem(Item item) +233
   Sitecore.Nexus.Data.DataCommands.AddVersionCommand.Execute(Item item) +379
   Sitecore.Data.Engines.EngineCommand`2.Execute() +96
   Sitecore.Data.Engines.DataEngine.AddVersion(Item item) +181
   Sitecore.Data.Managers.ItemProvider.AddVersion(Item item, SecurityCheck securityCheck) +257
   Sitecore.Data.Managers.PipelineBasedItemProvider.ExecuteAndReturnResult(String pipelineName, String pipelineDomain, Func`1 pipelineArgsCreator, Func`1 fallbackResult) +96
   Sitecore.Data.Managers.PipelineBasedItemProvider.AddVersion(Item item, SecurityCheck securityCheck) +239
   Sitecore.Nexus.Data.DataCommands.AddFromTemplateCommand.(String , Item , ID , ID ) +114
   Sitecore.Data.Engines.DataCommands.AddFromTemplateCommand.DoExecute() +116
   Sitecore.Buckets.Commands.AddFromTemplateCommand.DoExecute() +1251
   Sitecore.Data.Engines.EngineCommand`2.Execute() +96
   Sitecore.Data.Managers.ItemProvider.AddFromTemplate(String itemName, ID templateId, Item destination, ID newId) +375
   Sitecore.Data.Managers.<>c__DisplayClass3.<AddFromTemplate>b__2() +51
   Sitecore.Data.Managers.PipelineBasedItemProvider.ExecuteAndReturnResult(String pipelineName, String pipelineDomain, Func`1 pipelineArgsCreator, Func`1 fallbackResult) +96
   Sitecore.Data.Managers.ItemManager.AddFromTemplate(String itemName, ID templateId, Item destination, ID newItemId) +136
   Sitecore.Data.Managers.ItemManager.AddFromTemplate(String itemName, ID templateId, Item destination) +153
   Sitecore.Data.Items.Item.Add(String name, TemplateID templateID) +86
   Sitecore.Workflows.WorkflowContext.AddItem(String name, TemplateItem template, Item parent) +79
   Sitecore.Shell.Framework.Commands.AddMaster.Add(ClientPipelineArgs args) +855

[TargetInvocationException: Exception has been thrown by the target of an invocation.]
   System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor) +0
   System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(Object obj, Object[] parameters, Object[] arguments) +128
   System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture) +146
   Sitecore.Reflection.ReflectionUtil.InvokeMethod(MethodInfo method, Object[] parameters, Object obj) +89
   Sitecore.Nexus.Pipelines.NexusPipelineApi.Resume(PipelineArgs args, Pipeline pipeline) +313
   Sitecore.Web.UI.Sheer.ClientPage.ResumePipeline() +224
   Sitecore.Web.UI.Sheer.ClientPage.OnPreRender(EventArgs e) +823
   Sitecore.Shell.Applications.ContentManager.ContentEditorPage.OnPreRender(EventArgs e) +24
   System.Web.UI.Control.PreRenderRecursiveInternal() +200
   System.Web.UI.Page.ProcessRequestMain(Boolean includeStagesBeforeAsyncPoint, Boolean includeStagesAfterAsyncPoint) +7738`


That is happening because path with double dots is not transformed to its canonical form. 

As an example, if physicalRootPath = "~/../../Items", Site root is "c:\mysite\sandbox\website" and destination folder for serialized items is "c:\mysite\Items"

Without this fix system keeps path as "c:\mysite\sandbox\website\\..\\..\\Items". That works for file operations, but `string.Substring` fails later.

