### PR TITLE
Fix spelling and grammar in main Rainbow config

### DIFF
--- a/src/Rainbow/Rainbow.config
+++ b/src/Rainbow/Rainbow.config
@@ -11,7 +11,7 @@
 	<sitecore>
 		<settings>
 			<!--  Rainbow - SERIALIZATION FOLDER PATH MAX LENGTH
-				In Windows, there is 248 characters limit on the lenght of file system paths. To avoid exceeding the maximum path length, Rainbow will loop
+				In Windows, there is a 248 character limit on the length of file system paths. To avoid exceeding the maximum path length, Rainbow will loop
 						long paths back to the root. This setting specifies the maximum length of the path to the serialization root path,
 						which determines how long item paths can be before they are looped.
 				Important: The value of this setting must be the same on all Sitecore instances accessing the serialized data. 


### PR DESCRIPTION
While working through the Habitat implementation noticed that 'length' was spelled incorrectly in the main config.

This fixes that as well as tweaking the grammar in the same paragraph.